### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/vierkant-private/82fde4a1-f3a7-4728-9601-094eebe3b23b/8d4ce47d-c8f8-43f7-9f0a-e645f4839d28/_apis/work/boardbadge/541d2fcf-7c8d-45bd-adee-7a75ac8c8ae3)](https://dev.azure.com/vierkant-private/82fde4a1-f3a7-4728-9601-094eebe3b23b/_boards/board/t/8d4ce47d-c8f8-43f7-9f0a-e645f4839d28/Microsoft.RequirementCategory)
 # AzureFunctionsSamples


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#8](https://dev.azure.com/vierkant-private/82fde4a1-f3a7-4728-9601-094eebe3b23b/_workitems/edit/8). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.